### PR TITLE
Adds implementation for LocalReferencesKata

### DIFF
--- a/csharp-seven-kata-tests/LocalReferencesKataTests.cs
+++ b/csharp-seven-kata-tests/LocalReferencesKataTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using csharp_seven_kata;
 
 namespace csharp_seven_kata_tests
 {
@@ -9,7 +10,13 @@ namespace csharp_seven_kata_tests
         [TestMethod]
         public void Validate_Local_References()
         {
-            //TODO
+            const string message = "the more you know";
+
+            var localReferencesKata = new LocalReferencesKata();
+            localReferencesKata.SetMessage(message);
+
+            var shootingStar = localReferencesKata.GetShootingStar();
+            Assert.AreEqual(message, shootingStar.ToString());
         }
     }
 }

--- a/csharp-seven-kata/LocalReferencesKata.cs
+++ b/csharp-seven-kata/LocalReferencesKata.cs
@@ -11,8 +11,9 @@ namespace csharp_seven_kata
      */
     public class LocalReferencesKata
     {
-        //KATA: Replace _shootingStar.SetMessage(message) using ref locals and returns with GetMessageByRef()
-        //Note: You'll need to modify ShootingStar.GetMessageByRef() along with LocalReferencesKata.SetMessage(string message)
+        //KATA: Use the ref feature to set the message on _shootingStar without using _shootingStar.SetMessage(message).
+        //_shootingStar.GetMessageByRef() has been provided as a starting point. Modify GetMessageByRef() to return a 
+        //reference to _message that can be assigned from LocalReferencesKata.SetMessage().
         public void SetMessage(string message)
         {
             _shootingStar.SetMessage(message);

--- a/csharp-seven-kata/LocalReferencesKata.cs
+++ b/csharp-seven-kata/LocalReferencesKata.cs
@@ -6,9 +6,48 @@ namespace csharp_seven_kata
      * From: https://docs.microsoft.com/en-us/dotnet/articles/csharp/csharp-7#ref-locals-and-returns
      * This feature enables algorithms that use and return references to variables defined elsewhere.
      * These are useful for changing and returning references to specific memory instead of copying memory.
+     * 
+     * Avoiding the overhead of copying resources or pinning memory can be benefitial for high performance applications.
      */
     public class LocalReferencesKata
     {
-        //TODO
+        //KATA: Replace _shootingStar.SetMessage(message) using ref locals and returns with GetMessageByRef()
+        //Note: You'll need to modify ShootingStar.GetMessageByRef() along with LocalReferencesKata.SetMessage(string message)
+        public void SetMessage(string message)
+        {
+            _shootingStar.SetMessage(message);
+        }
+
+        private ShootingStar _shootingStar;
+
+        public LocalReferencesKata()
+        {
+            _shootingStar = new ShootingStar();
+        }
+
+        public ShootingStar GetShootingStar()
+        {
+            return _shootingStar;
+        }
+    }
+
+    public class ShootingStar
+    {
+        private string _message;
+
+        public string GetMessageByRef()
+        {
+            return _message;
+        }
+
+        public void SetMessage(string message)
+        {
+            _message = message;
+        }
+        
+        public override string ToString()
+        {
+            return _message;
+        }
     }
 }


### PR DESCRIPTION
This is a simple exercise meant to stress understanding of the following:
* Compiler enforcement of the `ref` keyword.
* Accessing by reference instead of a copy

Addresses issue: https://github.com/nickfloyd/csharp-seven-kata/issues/1